### PR TITLE
update mongo db native driver to 3.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/afloyd/mongo-migrate"
   },
   "dependencies": {
-    "mongodb": "3.2.3",
+    "mongodb": "3.6.6",
     "verror": "^1.6.0"
   },
   "main": "index",


### PR DESCRIPTION
@isaacverifly 
Policy要给索引加applicant_company_lower加索引的这个卡片
https://trello.com/c/YYCjfEp6

我们周五商量了要用update pipeline这种方式直接在migration里去做applicant_company_lower的初始化
https://docs.mongodb.com/manual/tutorial/update-documents-with-aggregation-pipeline/

但是我发现我们现在用的mongo db的版本里，updateMany这个方法不支持update pipeline的写法
```db.updateMany({}, [{$set:{applicant_company_lower: "XXXX"}])```

把mongo db的nodejs client更新到3.6.6之后，我测试了一下是支持了，并且跑了policy的整个测试，没有什么问题。

你帮忙评估一下，是否直接把mongo db的client版本升级一下？目前mongo db的版本最高是3.6.6，官方支持mongodb 4.4的版本是3.6.0
![image](https://user-images.githubusercontent.com/9735541/118391370-7b827a00-b666-11eb-82c3-6cb40d15809a.png)
