### PR TITLE
card-7302 add unique index for migration_lock

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -22,15 +22,6 @@ function getReplicaSetServers(opts, mongodb) {
 	return new mongodb.ReplSet(replServers);
 }
 
-function getMigrationsCollection(db, mongodb) {
-	// for mongodb 2.x
-	if (typeof db.collection !== 'undefined') {
-		return db.collection('migrations');
-	}
-
-	return db.collection('migrations');
-}
-
 function getConnection(opts, cb) {
 	var mongodb = require('mongodb');
 
@@ -47,7 +38,8 @@ function getConnection(opts, cb) {
 
 			cb(null, {
 				connection: db,
-				migrationCollection: getMigrationsCollection(db, mongodb)
+				migrationCollection: db.collection('migrations'),
+				migrationLockCollection: db.collection('migration_lock'),
 			});
 		});
 		return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-migrate",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Migration framework for mongo in node",
   "keywords": [
     "mongo",

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -121,7 +121,15 @@ describe('migrations tests', () => {
       expect(data.completed).to.be.true;
       expect(data.erred).to.be.false;
       expect(data.errMessages).to.be.empty;
-      done();
+      co(function *callback() {
+        const migrationLockColIndexes = yield migrationLockCol.indexes();
+        const numIndex = migrationLockColIndexes.find((index) => index.name === 'idx_migration_lock_num');
+        expect(numIndex.unique).to.be.true;
+      }).then(() => {
+        done();
+      }, (err) => {
+        done(err);
+      });
     });
   });
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* **What is the root cause (BUG FIX only)?**

  发布过程中，多台服务同时启动，由于时间点非常接近，导致migration_lock失效，因为migration_lock数据还没写入。

* **How do you fix the bug (BUG FIX only)?**

  对migration_lock添加唯一索引，这样即使多台服务器同时启动，写入migration_lock数据如果有重复也会失败，避免migration同时被重复执行

  1. 执行migration时先检查migration_lock是否有唯一索引，没有的话先创建。
  2. 另外需要考虑对历史有重复执行的migration做数据修复

* **Test Steps for the bug (BUG FIX only)?**

* **Impact Areas for the bug (BUG FIX only)?**

* **What is the new behavior of feature (FEATURE only)?**

  https://github.com/carasystems/api-policy/commit/5f2fbe1efcf6778bbbd1bc920beaa2a16a5d01f6

* **Asana link (if any)?**

* **Other information**:
